### PR TITLE
Dev/nich/point equals null bug

### DIFF
--- a/src/GShark.Test.XUnit/Geometry/Point3Tests.cs
+++ b/src/GShark.Test.XUnit/Geometry/Point3Tests.cs
@@ -154,6 +154,38 @@ namespace GShark.Test.XUnit.Geometry
         }
 
         [Fact]
+        public void It_Returns_True_If_Two_Points_Are_Equal_Null_Case1()
+        {
+            // Arrange
+            Point3 p1 = new Point3(5.982099, 5.950299, 0);
+            Point3 p2 = null;
+
+            // Assert
+            (p1 == p2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void It_Returns_True_If_Two_Points_Are_Equal_Null_Case2()
+        {
+            // Arrange
+            Point3 p1 = null;
+            Point3 p2 = new Point3(5.982099, 5.950299, 0);
+
+            // Assert
+            (p1 == p2).Should().BeFalse();
+        }
+        [Fact]
+        public void It_Returns_True_If_Two_Points_Are_Equal_Null_Case3()
+        {
+            // Arrange
+            Point3 p1 = null;
+            Point3 p2 = null;
+
+            // Assert
+            (p1 == p2).Should().BeFalse();
+        }
+
+        [Fact]
         public void It_Returns_Whether_A_Point_Is_Inside_Outside_Or_Coincident_With_A_Polygon()
         {
             //Arrange

--- a/src/GShark/Geometry/Point3.cs
+++ b/src/GShark/Geometry/Point3.cs
@@ -198,6 +198,12 @@ namespace GShark.Geometry
         /// <returns>true if the coordinates of the two points are exactly equal; otherwise false.</returns>
         public static bool operator ==(Point3 a, Point3 b)
         {
+            if (a == null && b == null)
+                return true;
+            if (a == null || b == null)
+                return false;
+            if (ReferenceEquals(a, b))
+                return true;
             return (Math.Abs(a.X - b.X) < GSharkMath.MaxTolerance
                     && Math.Abs(a.Y - b.Y) < GSharkMath.MaxTolerance
                     && Math.Abs(a.Z - b.Z) < GSharkMath.MaxTolerance);
@@ -384,6 +390,14 @@ namespace GShark.Geometry
         /// <returns>true if obj is a Point3 and has the same coordinates as this; otherwise false.</returns>
         public override bool Equals(object obj)
         {
+            if (obj == null)
+                return false;
+
+            if (ReferenceEquals(this, obj))
+                return true;
+
+            if (this.GetType() != obj.GetType())
+                return false;
             return obj is Point3 point3 && this == point3;
         }
 

--- a/src/GShark/Geometry/Point3.cs
+++ b/src/GShark/Geometry/Point3.cs
@@ -198,9 +198,9 @@ namespace GShark.Geometry
         /// <returns>true if the coordinates of the two points are exactly equal; otherwise false.</returns>
         public static bool operator ==(Point3 a, Point3 b)
         {
-            if (a == null && b == null)
-                return true;
-            if (a == null || b == null)
+            if (a is null && b is null)
+                return false;
+            if (a is null || b is null)
                 return false;
             if (ReferenceEquals(a, b))
                 return true;


### PR DESCRIPTION
### What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [ x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

### Description

Previously, the equals and the == operator of the Point3 didn't handle the null input case, ie if one (or both) of the inputs were null then the function would throw an error. I have modified the function to return false when either of the inputs is null or if both the inputs are null (the second scenario is what I have observed when I compared two string variables having null values).

This PR Fixes https://github.com/GSharker/G-Shark/issues/417 .

### Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

### Added tests?

- [ x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 docs
- [x ] 🙅 no documentation needed
